### PR TITLE
make UPRN int64

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The OpenAPI document for Broadband API has the following errata:
 - `GET /coverage/{PostCode}`
   - 200 response body schema
     - is missing the `Count` property (type: integer)
+    - `UPRN` property in `BroadbandProvision` has format `int32`, but this is too small and should be `int64`
   - 401 response is missing
     - body schema has:
       - `statusCode` (type: integer)

--- a/data/ofcom-connected-nations-broadband-api.yaml
+++ b/data/ofcom-connected-nations-broadband-api.yaml
@@ -101,7 +101,7 @@ components:
         UPRN:
           type: integer
           description: Unique Property Reference Number
-          format: int32
+          format: int64
         AddressShortDescription:
           type: string
           description: 'A compiled address description based on use of the Ordnance Survey AddressBase fields of the form - Building Name, Building Number, Dependent_ThoroughFare'


### PR DESCRIPTION
## What?

changes UPRN integer format from `int32` to `int64`

## Why?

spot-checking a value, 100041141892, is 37 bits, longer than 32

