### PR TITLE
change mobile UPRN to int64

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The OpenAPI document for Mobile API has the following errata:
   - 200 response body schema
     - is specified as `MobileAvailabilityArray` when it is actually `MobileAvailability`
     - is missing the `DBName` property (type: string)
+    - `UPRN` property in `MobileProvision` has format `int32`, but this is too small and should be `int64`
   - 401 response is missing
     - body schema has:
       - `statusCode` (type: integer)

--- a/data/ofcom-connected-nations-api.yaml
+++ b/data/ofcom-connected-nations-api.yaml
@@ -164,7 +164,7 @@ components:
         UPRN:
           type: integer
           description: Unique Property Reference Number
-          format: int32
+          format: int64
         AddressShortDescription:
           type: string
           description: 'A compiled address description based on use of the Ordnance Survey AddressBase fields of the form - Building Name, Building Number, Dependent_ThoroughFare'


### PR DESCRIPTION
## What?

Change UPRN integer format from int32 to int64

Same thing as #11 , but in the mobile OpenAPI

## Why?

The bit length of UPRN values is at least 37

